### PR TITLE
ADJUST1-161 unused remand changes for new API.

### DIFF
--- a/server/@types/adjustments/index.d.ts
+++ b/server/@types/adjustments/index.d.ts
@@ -73,6 +73,13 @@ export interface paths {
      */
     post: operations['create_1']
   }
+  '/adjustments/{adjustmentId}/effective-days': {
+    /**
+     * Update the effective calculable days for and adjustment
+     * @description Update an adjustment's effective days.
+     */
+    post: operations['updateEffectiveDays']
+  }
   '/adjustments/validate': {
     /**
      * Validate an adjustments
@@ -180,6 +187,7 @@ export interface components {
         | 'ADDITIONAL_DAYS_AWARDED'
         | 'RESTORATION_OF_ADDITIONAL_DAYS_AWARDED'
         | 'SPECIAL_REMISSION'
+        | 'UNUSED_DEDUCTIONS'
       /**
        * Format: date
        * @description The end date of the adjustment
@@ -219,6 +227,16 @@ export interface components {
        * @description The date and time this adjustment was last updated
        */
       lastUpdatedDate?: string
+      /**
+       * Format: int32
+       * @description The number of days effective in a calculation. (for example remand minus any unused deductions)
+       */
+      effectiveDays?: number
+      /**
+       * Format: int32
+       * @description The days between the from and two date
+       */
+      daysBetween?: number
     }
     /** @description The details of a UAL adjustment */
     UnlawfullyAtLargeDto: {
@@ -235,6 +253,21 @@ export interface components {
     CreateResponseDto: {
       /** Format: uuid */
       adjustmentId: string
+    }
+    /** @description Details of the adjustment and the number of effective days within a calculation. */
+    AdjustmentEffectiveDaysDto: {
+      /**
+       * Format: uuid
+       * @description The ID of the adjustment
+       */
+      id: string
+      /**
+       * Format: int32
+       * @description The number of days effective in a calculation. (for example remand minus any unused deductions)
+       */
+      effectiveDays: number
+      /** @description The NOMIS ID of the person this adjustment applies to */
+      person: string
     }
     /** @description Validation message details */
     ValidationMessage: {
@@ -578,6 +611,31 @@ export interface operations {
           'application/json': components['schemas']['CreateResponseDto']
         }
       }
+    }
+  }
+  /**
+   * Update the effective calculable days for and adjustment
+   * @description Update an adjustment's effective days.
+   */
+  updateEffectiveDays: {
+    parameters: {
+      path: {
+        /** @description The adjustment UUID */
+        adjustmentId: string
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AdjustmentEffectiveDaysDto']
+      }
+    }
+    responses: {
+      /** @description Adjustment update */
+      200: never
+      /** @description Unauthorised, requires a valid Oauth2 token */
+      401: never
+      /** @description Adjustment not found */
+      404: never
     }
   }
   /**

--- a/server/model/adjustmentsHubViewModel.ts
+++ b/server/model/adjustmentsHubViewModel.ts
@@ -66,7 +66,7 @@ export default class AdjustmentsHubViewModel {
   public getTotalDays(adjustmentType: AdjustmentType) {
     return this.adjustments
       .filter(it => it.adjustmentType === adjustmentType.value)
-      .map(a => a.days)
+      .map(a => a.days || a.daysBetween || a.effectiveDays)
       .reduce((sum, current) => sum + current, 0)
   }
 

--- a/server/model/reviewAndSubmitAdaViewModel.ts
+++ b/server/model/reviewAndSubmitAdaViewModel.ts
@@ -13,7 +13,9 @@ export default class ReviewAndSubmitAdaViewModel {
   public displayBanner(): boolean {
     const anyUnlinkedAdas = this.existingAdjustments.some(it => !it.additionalDaysAwarded?.adjudicationId?.length)
     if (anyUnlinkedAdas) {
-      const existingDays = this.existingAdjustments.map(a => a.days).reduce((sum, current) => sum + current, 0)
+      const existingDays = this.existingAdjustments
+        .map(a => a.days || a.effectiveDays)
+        .reduce((sum, current) => sum + current, 0)
       const newDays = this.adjustments.map(a => a.days).reduce((sum, current) => sum + current, 0)
       return existingDays !== newDays
     }

--- a/server/model/reviewModel.ts
+++ b/server/model/reviewModel.ts
@@ -63,14 +63,14 @@ export default class ReviewModel {
           text: dayjs(adjustment.fromDate).format('D MMM YYYY'),
         },
       },
-      ...(adjustment.days
+      ...(adjustment.days || adjustment.daysBetween || adjustment.effectiveDays
         ? [
             {
               key: {
                 text: 'Days',
               },
               value: {
-                text: adjustment.days,
+                text: adjustment.days || adjustment.daysBetween || adjustment.effectiveDays,
               },
             },
           ]
@@ -114,7 +114,7 @@ export default class ReviewModel {
           text: 'Number of days',
         },
         value: {
-          text: adjustment.days,
+          text: adjustment.daysBetween || adjustment.effectiveDays,
         },
       },
       {

--- a/server/model/unlawfullyAtLargeForm.ts
+++ b/server/model/unlawfullyAtLargeForm.ts
@@ -32,7 +32,6 @@ export default class UnlawfullyAtLargeForm extends AdjustmentsForm<UnlawfullyAtL
       toDate,
       person: nomsId,
       unlawfullyAtLarge: { type: this.type },
-      days: daysBetween(new Date(fromDate), new Date(toDate)),
       prisonId: prisonerDetails.agencyId,
     }
   }

--- a/server/model/viewModel.ts
+++ b/server/model/viewModel.ts
@@ -62,7 +62,7 @@ export default class ViewModel {
         return [
           { text: dayjs(it.fromDate).format('D MMM YYYY') },
           { text: it.prisonName || 'Unknown' },
-          { text: it.days, format: 'numeric' },
+          { text: it.days || it.daysBetween || it.effectiveDays, format: 'numeric' },
           this.actionCell(it),
         ]
       })
@@ -74,7 +74,7 @@ export default class ViewModel {
           { text: dayjs(it.toDate).format('D MMM YYYY') },
           { text: it.prisonName || 'Unknown' },
           { text: it.unlawfullyAtLarge ? ualType.find(u => u.value === it.unlawfullyAtLarge.type)?.text : 'Unknown' },
-          { text: it.days, format: 'numeric' },
+          { text: it.days || it.daysBetween || it.effectiveDays, format: 'numeric' },
           this.actionCell(it),
         ]
       })
@@ -83,7 +83,7 @@ export default class ViewModel {
       return [
         { text: dayjs(it.fromDate).format('D MMM YYYY') },
         ...(this.adjustmentType.value === 'REMAND' ? [{ text: dayjs(it.toDate).format('D MMM YYYY') }] : []),
-        { text: it.days, format: 'numeric' },
+        { text: it.days || it.daysBetween || it.effectiveDays, format: 'numeric' },
         { text: it.prisonName || 'Unknown' },
         this.actionCell(it),
       ]
@@ -91,7 +91,7 @@ export default class ViewModel {
   }
 
   public totalRow() {
-    const total = this.adjustments.map(it => it.days).reduce((a, b) => a + b, 0)
+    const total = this.adjustments.map(it => it.days || it.daysBetween || it.effectiveDays).reduce((a, b) => a + b, 0)
     if (
       this.adjustmentType.value === 'RESTORATION_OF_ADDITIONAL_DAYS_AWARDED' ||
       this.adjustmentType.value === 'REMAND'

--- a/server/routes/adjustmentRoutes.ts
+++ b/server/routes/adjustmentRoutes.ts
@@ -225,11 +225,11 @@ export default class AdjustmentRoutes {
       }
       const message = {
         type: adjustment.adjustmentType,
-        days: adjustment.days,
+        days: adjustment.days || adjustment.daysBetween || adjustment.effectiveDays,
         action: adjustment.id ? 'UPDATE' : 'CREATE',
       } as Message
       adjustment = await this.adjustmentsService.get(adjustmentId, token)
-      message.days = adjustment.days
+      message.days = adjustment.days || adjustment.daysBetween || adjustment.effectiveDays
       return res.redirect(`/${nomsId}/success?message=${JSON.stringify(message)}`)
     }
     return res.redirect(`/${nomsId}`)
@@ -320,7 +320,7 @@ export default class AdjustmentRoutes {
     await this.adjustmentsService.delete(id, token)
     const message = JSON.stringify({
       type: adjustment.adjustmentType,
-      days: adjustment.days,
+      days: adjustment.days || adjustment.daysBetween || adjustment.effectiveDays,
       action: 'REMOVE',
     } as Message)
     return res.redirect(`/${nomsId}/success?message=${message}`)

--- a/server/services/additionalDaysAwardedService.ts
+++ b/server/services/additionalDaysAwardedService.ts
@@ -236,7 +236,7 @@ export default class AdditionalDaysAwardedService {
 
   private adjustmentMatchesAdjudication(adjudication: AdasByDateCharged, adjustment: Adjustment): boolean {
     return (
-      adjudication.total === adjustment.days &&
+      adjudication.total === (adjustment.days || adjustment.daysBetween || adjustment.effectiveDays) &&
       adjudication.dateChargeProved.toISOString().substring(0, 10) === adjustment.fromDate &&
       JSON.stringify(adjudication.charges.map(charge => charge.chargeNumber).sort()) ===
         JSON.stringify(adjustment.additionalDaysAwarded.adjudicationId.sort())


### PR DESCRIPTION
There is a lot of this repeated in the code. `adjustment.days || adjustment.daysBetween || adjustment.effectiveDays`

We might need to improve the API again to reduce this. I think maybe a different DTO for create and view.