### PR TITLE
ADJUST1-294 add validation from the CRD api to check overlapping remand dates on edit (to make consistent with add journey)

### DIFF
--- a/server/model/remandChangeModel.ts
+++ b/server/model/remandChangeModel.ts
@@ -1,16 +1,61 @@
+import dayjs from 'dayjs'
 import { Adjustment } from '../@types/adjustments/adjustmentsTypes'
 import { PrisonApiOffenderSentenceAndOffences, PrisonApiPrisoner } from '../@types/prisonApi/prisonClientTypes'
+import { CalculateReleaseDatesValidationMessage } from '../@types/calculateReleaseDates/calculateReleaseDatesClientTypes'
+import { calculateReleaseDatesCheckInformationUrl } from '../utils/utils'
 
 export default class RemandChangeModel {
+  remandRelatedValidationCodes = ['REMAND_OVERLAPS_WITH_REMAND', 'REMAND_OVERLAPS_WITH_SENTENCE']
+
   constructor(
     public prisonerDetail: PrisonApiPrisoner,
     public adjustment: Adjustment,
     private sentencesAndOffences: PrisonApiOffenderSentenceAndOffences[],
+    private calculateReleaseDatesValidationMessages: CalculateReleaseDatesValidationMessage[] = [],
   ) {}
 
   public listOffences() {
     return this.sentencesAndOffences.flatMap(so => {
       return so.offences.filter(off => this.adjustment.remand?.chargeId.includes(off.offenderChargeId))
     })
+  }
+
+  private remandRelatedValidation() {
+    return this.calculateReleaseDatesValidationMessages.filter(it =>
+      this.remandRelatedValidationCodes.includes(it.code),
+    )
+  }
+
+  public remandRelatedValidationSummary() {
+    const message = this.remandRelatedValidation().length ? this.remandRelatedValidation()[0] : null
+    if (!message) {
+      return {
+        errorList: [] as string[],
+      }
+    }
+    const overlapsWithRemand = message.code === 'REMAND_OVERLAPS_WITH_REMAND'
+    return {
+      titleText: overlapsWithRemand
+        ? 'Remand time cannot overlap'
+        : 'Remand cannot be applied when a sentence is being served.',
+      errorList: [
+        {
+          text: `The remand dates from ${dayjs(message.arguments[2]).format('DD MMM YYYY')} to ${dayjs(
+            message.arguments[3],
+          ).format('DD MMM YYYY')} overlaps with ${
+            overlapsWithRemand ? 'another remand period' : 'a sentence'
+          } from ${dayjs(message.arguments[0]).format('DD MMM YYYY')} to ${dayjs(message.arguments[1]).format(
+            'DD MMM YYYY',
+          )}`,
+        },
+      ],
+      subText: {
+        html: overlapsWithRemand
+          ? '<p>To continue, edit the remand days that overlap or Cancel.</p>'
+          : `<p>Update the remand dates to continue.</p><p>You can view the court case & sentence information in the <a href="${calculateReleaseDatesCheckInformationUrl(
+              this.prisonerDetail,
+            )}">Calculate release dates service</a>.</p>`,
+      },
+    }
   }
 }

--- a/server/views/pages/adjustments/remand/edit.njk
+++ b/server/views/pages/adjustments/remand/edit.njk
@@ -2,6 +2,7 @@
 {% from "./partials/remandSummary.njk" import remandSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = applicationName + " - View remand details" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -17,6 +18,32 @@
 {% endblock %}
 
 {% block content %}
+  {% if model.remandRelatedValidationSummary().errorList.length %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        {% set errorBody %}
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              {% for error in model
+                .remandRelatedValidationSummary()
+              .errorList %}
+                <li>
+                  <p class="govuk-body">{{ error.text }}</p>
+                </li>
+              {% endfor %}
+            </ul>
+            {{ model.remandRelatedValidationSummary().subText.html | safe }}
+          </div>
+        {% endset -%}
+
+        {{ govukErrorSummary({
+          titleText: model.remandRelatedValidationSummary().titleText,
+          errorList: [],
+          descriptionHtml: errorBody
+        }) }}
+      </div>
+    </div>
+  {% endif %}
   <h1 class="govuk-heading-xl"><span class="govuk-caption-xl">Adjust release dates</span>
     Edit remand details
   </h1>
@@ -33,11 +60,13 @@
       <form method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         <div class="govuk-button-group">
-          {{ govukButton({
-            text: "Save",
-            type: submit,
-            preventDoubleClick: true
-          }) }}
+          {% if not model.remandRelatedValidationSummary().errorList.length %}
+            {{ govukButton({
+              text: "Save",
+              type: submit,
+              preventDoubleClick: true
+            }) }}
+          {% endif %}
 
           {{ govukButton({
             text: "Cancel",


### PR DESCRIPTION
Have implemented the validation of overlapping periods in a similar way to the 'Add journey', where it does it on the load of the screen  (in the GET).

The validation should possibly be moved to SUBMIT for both ADD and EDIT journeys.. as having it in the GET allows for the possibility of validation errors not being picked up when they click Save (The underlying sentence data used for validation may change whilst they are on the screen)