### PR TITLE
ADJUST1-322 Add initial version of 'add-tagged-bail days' screen

### DIFF
--- a/server/@types/adjustments/index.d.ts
+++ b/server/@types/adjustments/index.d.ts
@@ -105,7 +105,7 @@ export interface components {
   schemas: {
     DlqMessage: {
       body: {
-        [key: string]: Record<string, never> | undefined
+        [key: string]: Record<string, never>
       }
       messageId: string
     }
@@ -208,6 +208,7 @@ export interface components {
       remand?: components['schemas']['RemandDto']
       additionalDaysAwarded?: components['schemas']['AdditionalDaysAwardedDto']
       unlawfullyAtLarge?: components['schemas']['UnlawfullyAtLargeDto']
+      taggedBail?: components['schemas']['TaggedBailDto']
       /**
        * @description The prison where the prisoner was located at the time the adjustment was created (a 3 character code identifying the prison)
        * @example LDS
@@ -250,6 +251,14 @@ export interface components {
     RemandDto: {
       /** @description The id of the charges this remand applies to */
       chargeId: number[]
+    }
+    /** @description The details of the tagged bail adjustment */
+    TaggedBailDto: {
+      /**
+       * Format: int32
+       * @description The case sequence number this tagged-bail was associated with
+       */
+      caseSequence: number
     }
     /** @description The details of a UAL adjustment */
     UnlawfullyAtLargeDto: {
@@ -325,6 +334,8 @@ export interface components {
   headers: never
   pathItems: never
 }
+
+export type $defs = Record<string, never>
 
 export type external = Record<string, never>
 
@@ -419,11 +430,17 @@ export interface operations {
     }
     responses: {
       /** @description Adjustment update */
-      200: never
+      200: {
+        content: never
+      }
       /** @description Unauthorised, requires a valid Oauth2 token */
-      401: never
+      401: {
+        content: never
+      }
       /** @description Adjustment not found */
-      404: never
+      404: {
+        content: never
+      }
     }
   }
   /**
@@ -439,11 +456,17 @@ export interface operations {
     }
     responses: {
       /** @description Adjustment deleted */
-      200: never
+      200: {
+        content: never
+      }
       /** @description Unauthorised, requires a valid Oauth2 token */
-      401: never
+      401: {
+        content: never
+      }
       /** @description Adjustment not found */
-      404: never
+      404: {
+        content: never
+      }
     }
   }
   /**
@@ -496,11 +519,17 @@ export interface operations {
     }
     responses: {
       /** @description Adjustment update */
-      200: never
+      200: {
+        content: never
+      }
       /** @description Unauthorised, requires a valid Oauth2 token */
-      401: never
+      401: {
+        content: never
+      }
       /** @description Adjustment not found */
-      404: never
+      404: {
+        content: never
+      }
     }
   }
   /**
@@ -516,11 +545,17 @@ export interface operations {
     }
     responses: {
       /** @description Adjustment deleted */
-      200: never
+      200: {
+        content: never
+      }
       /** @description Unauthorised, requires a valid Oauth2 token */
-      401: never
+      401: {
+        content: never
+      }
       /** @description Adjustment not found */
-      404: never
+      404: {
+        content: never
+      }
     }
   }
   /**
@@ -652,11 +687,17 @@ export interface operations {
     }
     responses: {
       /** @description Adjustment update */
-      200: never
+      200: {
+        content: never
+      }
       /** @description Unauthorised, requires a valid Oauth2 token */
-      401: never
+      401: {
+        content: never
+      }
       /** @description Adjustment not found */
-      404: never
+      404: {
+        content: never
+      }
     }
   }
   /**
@@ -696,11 +737,17 @@ export interface operations {
     }
     responses: {
       /** @description Adjustment restored */
-      200: never
+      200: {
+        content: never
+      }
       /** @description Unauthorised, requires a valid Oauth2 token */
-      401: never
+      401: {
+        content: never
+      }
       /** @description Adjustment not found */
-      404: never
+      404: {
+        content: never
+      }
     }
   }
   getDlqMessages: {

--- a/server/model/taggedBailDaysModel.ts
+++ b/server/model/taggedBailDaysModel.ts
@@ -1,0 +1,17 @@
+import { PrisonApiOffenderSentenceAndOffences, PrisonApiPrisoner } from '../@types/prisonApi/prisonClientTypes'
+
+type SentencesByCaseSequence = {
+  caseSequence: number
+  sentences: PrisonApiOffenderSentenceAndOffences[]
+}
+
+export default class TaggedBailDaysModel {
+  constructor(
+      public prisonerDetail: PrisonApiPrisoner,
+      private addOrEdit: string,
+      private id: string) {}
+
+  public backlink(): string {
+    return `/${this.prisonerDetail.offenderNo}`
+  }
+}

--- a/server/model/taggedBailDaysModel.ts
+++ b/server/model/taggedBailDaysModel.ts
@@ -1,15 +1,11 @@
-import { PrisonApiOffenderSentenceAndOffences, PrisonApiPrisoner } from '../@types/prisonApi/prisonClientTypes'
-
-type SentencesByCaseSequence = {
-  caseSequence: number
-  sentences: PrisonApiOffenderSentenceAndOffences[]
-}
+import { PrisonApiPrisoner } from '../@types/prisonApi/prisonClientTypes'
 
 export default class TaggedBailDaysModel {
   constructor(
-      public prisonerDetail: PrisonApiPrisoner,
-      private addOrEdit: string,
-      private id: string) {}
+    public prisonerDetail: PrisonApiPrisoner,
+    private addOrEdit: string,
+    private id: string,
+  ) {}
 
   public backlink(): string {
     return `/${this.prisonerDetail.offenderNo}/tagged-bail/select-case/${this.addOrEdit}/${this.id}`

--- a/server/model/taggedBailDaysModel.ts
+++ b/server/model/taggedBailDaysModel.ts
@@ -12,6 +12,6 @@ export default class TaggedBailDaysModel {
       private id: string) {}
 
   public backlink(): string {
-    return `/${this.prisonerDetail.offenderNo}`
+    return `/${this.prisonerDetail.offenderNo}/tagged-bail/select-case/${this.addOrEdit}/${this.id}`
   }
 }

--- a/server/model/taggedBailSelectCaseModel.ts
+++ b/server/model/taggedBailSelectCaseModel.ts
@@ -7,9 +7,11 @@ type SentencesByCaseSequence = {
 
 export default class TaggedBailSelectCaseModel {
   constructor(
-      public prisonerDetail: PrisonApiPrisoner,
-      private sentencesAndOffences: PrisonApiOffenderSentenceAndOffences[],
-      private addOrEdit: string, private id: string) {}
+    public prisonerDetail: PrisonApiPrisoner,
+    private sentencesAndOffences: PrisonApiOffenderSentenceAndOffences[],
+    private addOrEdit: string,
+    private id: string,
+  ) {}
 
   public backlink(): string {
     return `/${this.prisonerDetail.offenderNo}`

--- a/server/model/taggedBailSelectCaseModel.ts
+++ b/server/model/taggedBailSelectCaseModel.ts
@@ -1,5 +1,10 @@
 import { PrisonApiOffenderSentenceAndOffences, PrisonApiPrisoner } from '../@types/prisonApi/prisonClientTypes'
 
+type SentencesByCaseSequence = {
+  caseSequence: number
+  sentences: PrisonApiOffenderSentenceAndOffences[]
+}
+
 export default class TaggedBailSelectCaseModel {
   constructor(
     public prisonerDetail: PrisonApiPrisoner,
@@ -10,7 +15,25 @@ export default class TaggedBailSelectCaseModel {
     return `/${this.prisonerDetail.offenderNo}`
   }
 
+  // returns the sentence data for each unique case sequence; i.e. the record that has the earliest sentence date when multiple ones exist
   public activeSentences(): PrisonApiOffenderSentenceAndOffences[] {
-    return this.sentencesAndOffences.filter(it => it.sentenceStatus === 'A')
+    const sentencesBySequenceNumber = this.getSentencesByCaseSequence()
+    return sentencesBySequenceNumber.map(it => {
+      return it.sentences.sort((a, b) => new Date(a.sentenceDate).getTime() - new Date(b.sentenceDate).getTime())[0]
+    })
+  }
+
+  private getSentencesByCaseSequence(): SentencesByCaseSequence[] {
+    return this.sentencesAndOffences
+      .filter(it => it.sentenceStatus === 'A')
+      .reduce((acc: SentencesByCaseSequence[], cur) => {
+        if (acc.some(it => it.caseSequence === cur.caseSequence)) {
+          const record = acc.find(it => it.caseSequence === cur.caseSequence)
+          record.sentences.push(cur)
+        } else {
+          acc.push({ caseSequence: cur.caseSequence, sentences: [cur] } as SentencesByCaseSequence)
+        }
+        return acc
+      }, [])
   }
 }

--- a/server/model/taggedBailSelectCaseModel.ts
+++ b/server/model/taggedBailSelectCaseModel.ts
@@ -7,9 +7,9 @@ type SentencesByCaseSequence = {
 
 export default class TaggedBailSelectCaseModel {
   constructor(
-    public prisonerDetail: PrisonApiPrisoner,
-    private sentencesAndOffences: PrisonApiOffenderSentenceAndOffences[],
-  ) {}
+      public prisonerDetail: PrisonApiPrisoner,
+      private sentencesAndOffences: PrisonApiOffenderSentenceAndOffences[],
+      private addOrEdit: string, private id: string) {}
 
   public backlink(): string {
     return `/${this.prisonerDetail.offenderNo}`

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -81,6 +81,7 @@ export default function routes(service: Services): Router {
 
   get('/:nomsId/tagged-bail/add', taggedBailRoutes.add)
   get('/:nomsId/tagged-bail/select-case/:addOrEdit/:id', taggedBailRoutes.selectCase)
+  get('/:nomsId/tagged-bail/days/:addOrEdit/:id', taggedBailRoutes.days)
 
   get('/:nomsId/:adjustmentTypeUrl/view', adjustmentRoutes.view)
   get('/:nomsId/:adjustmentTypeUrl/remove/:id', adjustmentRoutes.remove)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -80,6 +80,7 @@ export default function routes(service: Services): Router {
   get('/:nomsId/remand/no-applicable-sentences', remandRoutes.noApplicableSentences)
 
   get('/:nomsId/tagged-bail/add', taggedBailRoutes.add)
+  get('/:nomsId/tagged-bail/select-case/:addOrEdit/:id', taggedBailRoutes.selectCase)
 
   get('/:nomsId/:adjustmentTypeUrl/view', adjustmentRoutes.view)
   get('/:nomsId/:adjustmentTypeUrl/remove/:id', adjustmentRoutes.remove)

--- a/server/routes/taggedBailRoutes.test.ts
+++ b/server/routes/taggedBailRoutes.test.ts
@@ -37,6 +37,7 @@ const sentenceAndOffenceBaseRecord = {
     },
   ],
   sentenceTypeDescription: 'SDS Standard Sentence',
+  sentenceDate: '2021-08-20',
   caseSequence: 1,
   lineSequence: 1,
   caseReference: 'CASE001',
@@ -54,7 +55,17 @@ const sentenceAndOffenceBaseRecord = {
   ],
 } as PrisonApiOffenderSentenceAndOffences
 
-const stubbedSentencesAndOffences = [sentenceAndOffenceBaseRecord]
+const stubbedSentencesAndOffences = [
+  sentenceAndOffenceBaseRecord,
+  { ...sentenceAndOffenceBaseRecord, sentenceDate: '2021-08-19', courtDescription: 'Court 2' },
+  {
+    ...sentenceAndOffenceBaseRecord,
+    caseSequence: 2,
+    caseReference: 'CASE002',
+    sentenceDate: '2021-08-30',
+    courtDescription: 'Court 3',
+  },
+]
 
 let app: Express
 
@@ -91,7 +102,9 @@ describe('Tagged bail routes tests', () => {
       .get(`/${NOMS_ID}/tagged-bail/select-case/add/${SESSION_ID}`)
       .expect(200)
       .expect(res => {
-        expect(res.text).toContain('Court 1')
+        expect(res.text).toContain('Court 2')
+        expect(res.text).toContain('Court 3')
+        expect(res.text).not.toContain('Court 1')
       })
   })
 })

--- a/server/routes/taggedBailRoutes.test.ts
+++ b/server/routes/taggedBailRoutes.test.ts
@@ -74,12 +74,21 @@ afterEach(() => {
 })
 
 describe('Tagged bail routes tests', () => {
-  it('GET /{nomsId}/tagged-bail/add shows correct information', () => {
+  it('GET /{nomsId}/tagged-bail/add redirects correctly', () => {
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     adjustmentsStoreService.store.mockReturnValue(SESSION_ID)
     prisonerService.getSentencesAndOffencesFilteredForRemand.mockResolvedValue(stubbedSentencesAndOffences)
     return request(app)
       .get(`/${NOMS_ID}/tagged-bail/add`)
+      .expect(302)
+      .expect('Location', `/${NOMS_ID}/tagged-bail/select-case/add/${SESSION_ID}`)
+  })
+
+  it('GET /{nomsId}/tagged-bail/select-case/add shows correct information', () => {
+    prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
+    prisonerService.getSentencesAndOffencesFilteredForRemand.mockResolvedValue(stubbedSentencesAndOffences)
+    return request(app)
+      .get(`/${NOMS_ID}/tagged-bail/select-case/add/${SESSION_ID}`)
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Court 1')

--- a/server/routes/taggedBailRoutes.test.ts
+++ b/server/routes/taggedBailRoutes.test.ts
@@ -107,4 +107,15 @@ describe('Tagged bail routes tests', () => {
         expect(res.text).not.toContain('Court 1')
       })
   })
+
+  it('GET /{nomsId}/tagged-bail/days/add shows correct information', () => {
+    prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
+    prisonerService.getSentencesAndOffences.mockResolvedValue(stubbedSentencesAndOffences)
+    return request(app)
+      .get(`/${NOMS_ID}/tagged-bail/days/add/${SESSION_ID}`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Enter the amount of tagged bail')
+      })
+  })
 })

--- a/server/routes/taggedBailRoutes.test.ts
+++ b/server/routes/taggedBailRoutes.test.ts
@@ -77,7 +77,7 @@ describe('Tagged bail routes tests', () => {
   it('GET /{nomsId}/tagged-bail/add redirects correctly', () => {
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
     adjustmentsStoreService.store.mockReturnValue(SESSION_ID)
-    prisonerService.getSentencesAndOffencesFilteredForRemand.mockResolvedValue(stubbedSentencesAndOffences)
+    prisonerService.getSentencesAndOffences.mockResolvedValue(stubbedSentencesAndOffences)
     return request(app)
       .get(`/${NOMS_ID}/tagged-bail/add`)
       .expect(302)
@@ -86,7 +86,7 @@ describe('Tagged bail routes tests', () => {
 
   it('GET /{nomsId}/tagged-bail/select-case/add shows correct information', () => {
     prisonerService.getPrisonerDetail.mockResolvedValue(stubbedPrisonerData)
-    prisonerService.getSentencesAndOffencesFilteredForRemand.mockResolvedValue(stubbedSentencesAndOffences)
+    prisonerService.getSentencesAndOffences.mockResolvedValue(stubbedSentencesAndOffences)
     return request(app)
       .get(`/${NOMS_ID}/tagged-bail/select-case/add/${SESSION_ID}`)
       .expect(200)

--- a/server/routes/taggedBailRoutes.ts
+++ b/server/routes/taggedBailRoutes.ts
@@ -4,7 +4,7 @@ import AdjustmentsService from '../services/adjustmentsService'
 import AdjustmentsStoreService from '../services/adjustmentsStoreService'
 import CalculateReleaseDatesService from '../services/calculateReleaseDatesService'
 import TaggedBailSelectCaseModel from '../model/taggedBailSelectCaseModel'
-import TaggedBailDaysModel from "../model/taggedBailDaysModell";
+import TaggedBailDaysModel from "../model/taggedBailDaysModel";
 
 export default class TaggedBailRoutes {
   constructor(
@@ -45,6 +45,8 @@ export default class TaggedBailRoutes {
     const { nomsId, addOrEdit, id } = req.params
     const { caseSequence } = req.query as Record<string, string>
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
+    const adjustment = this.adjustmentsStoreService.getById(req, nomsId, id)
+    this.adjustmentsStoreService.store(req, nomsId, id, {...adjustment, taggedBail: {caseSequence: caseSequence as unknown as number}})
 
     return res.render('pages/adjustments/tagged-bail/days', {
       model: new TaggedBailDaysModel(prisonerDetail, addOrEdit, id),

--- a/server/routes/taggedBailRoutes.ts
+++ b/server/routes/taggedBailRoutes.ts
@@ -4,6 +4,7 @@ import AdjustmentsService from '../services/adjustmentsService'
 import AdjustmentsStoreService from '../services/adjustmentsStoreService'
 import CalculateReleaseDatesService from '../services/calculateReleaseDatesService'
 import TaggedBailSelectCaseModel from '../model/taggedBailSelectCaseModel'
+import TaggedBailDaysModel from "../model/taggedBailDaysModell";
 
 export default class TaggedBailRoutes {
   constructor(
@@ -30,26 +31,23 @@ export default class TaggedBailRoutes {
 
   public selectCase: RequestHandler = async (req, res): Promise<void> => {
     const { caseloads, token } = res.locals.user
-    const { nomsId } = req.params
+    const { nomsId, addOrEdit, id } = req.params
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
     const sentencesAndOffences = await this.prisonerService.getSentencesAndOffences(prisonerDetail.bookingId, token)
 
     return res.render('pages/adjustments/tagged-bail/select-case', {
-      model: new TaggedBailSelectCaseModel(prisonerDetail, sentencesAndOffences),
+      model: new TaggedBailSelectCaseModel(prisonerDetail, sentencesAndOffences, addOrEdit, id),
     })
   }
 
   public days: RequestHandler = async (req, res): Promise<void> => {
     const { caseloads, token } = res.locals.user
-    const { nomsId } = req.params
+    const { nomsId, addOrEdit, id } = req.params
+    const { caseSequence } = req.query as Record<string, string>
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
-    const sentencesAndOffences = await this.prisonerService.getSentencesAndOffencesFilteredForRemand(
-      prisonerDetail.bookingId,
-      token,
-    )
 
     return res.render('pages/adjustments/tagged-bail/days', {
-      model: new TaggedBailSelectCaseModel(prisonerDetail, sentencesAndOffences),
+      model: new TaggedBailDaysModel(prisonerDetail, addOrEdit, id),
     })
   }
 }

--- a/server/routes/taggedBailRoutes.ts
+++ b/server/routes/taggedBailRoutes.ts
@@ -32,10 +32,7 @@ export default class TaggedBailRoutes {
     const { caseloads, token } = res.locals.user
     const { nomsId } = req.params
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
-    const sentencesAndOffences = await this.prisonerService.getSentencesAndOffencesFilteredForRemand(
-      prisonerDetail.bookingId,
-      token,
-    )
+    const sentencesAndOffences = await this.prisonerService.getSentencesAndOffences(prisonerDetail.bookingId, token)
 
     return res.render('pages/adjustments/tagged-bail/select-case', {
       model: new TaggedBailSelectCaseModel(prisonerDetail, sentencesAndOffences),

--- a/server/routes/taggedBailRoutes.ts
+++ b/server/routes/taggedBailRoutes.ts
@@ -17,12 +17,41 @@ export default class TaggedBailRoutes {
     const { caseloads, token } = res.locals.user
     const { nomsId } = req.params
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
+
+    const sessionId = this.adjustmentsStoreService.store(req, nomsId, null, {
+      adjustmentType: 'TAGGED_BAIL',
+      bookingId: prisonerDetail.bookingId,
+      person: nomsId,
+      prisonId: prisonerDetail.agencyId,
+    })
+
+    return res.redirect(`/${nomsId}/tagged-bail/select-case/add/${sessionId}`)
+  }
+
+  public selectCase: RequestHandler = async (req, res): Promise<void> => {
+    const { caseloads, token } = res.locals.user
+    const { nomsId } = req.params
+    const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
     const sentencesAndOffences = await this.prisonerService.getSentencesAndOffencesFilteredForRemand(
       prisonerDetail.bookingId,
       token,
     )
 
     return res.render('pages/adjustments/tagged-bail/select-case', {
+      model: new TaggedBailSelectCaseModel(prisonerDetail, sentencesAndOffences),
+    })
+  }
+
+  public days: RequestHandler = async (req, res): Promise<void> => {
+    const { caseloads, token } = res.locals.user
+    const { nomsId } = req.params
+    const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
+    const sentencesAndOffences = await this.prisonerService.getSentencesAndOffencesFilteredForRemand(
+      prisonerDetail.bookingId,
+      token,
+    )
+
+    return res.render('pages/adjustments/tagged-bail/days', {
       model: new TaggedBailSelectCaseModel(prisonerDetail, sentencesAndOffences),
     })
   }

--- a/server/routes/taggedBailRoutes.ts
+++ b/server/routes/taggedBailRoutes.ts
@@ -4,7 +4,7 @@ import AdjustmentsService from '../services/adjustmentsService'
 import AdjustmentsStoreService from '../services/adjustmentsStoreService'
 import CalculateReleaseDatesService from '../services/calculateReleaseDatesService'
 import TaggedBailSelectCaseModel from '../model/taggedBailSelectCaseModel'
-import TaggedBailDaysModel from "../model/taggedBailDaysModel";
+import TaggedBailDaysModel from '../model/taggedBailDaysModel'
 
 export default class TaggedBailRoutes {
   constructor(
@@ -46,7 +46,10 @@ export default class TaggedBailRoutes {
     const { caseSequence } = req.query as Record<string, string>
     const prisonerDetail = await this.prisonerService.getPrisonerDetail(nomsId, caseloads, token)
     const adjustment = this.adjustmentsStoreService.getById(req, nomsId, id)
-    this.adjustmentsStoreService.store(req, nomsId, id, {...adjustment, taggedBail: {caseSequence: caseSequence as unknown as number}})
+    this.adjustmentsStoreService.store(req, nomsId, id, {
+      ...adjustment,
+      taggedBail: { caseSequence: caseSequence as unknown as number },
+    })
 
     return res.render('pages/adjustments/tagged-bail/days', {
       model: new TaggedBailDaysModel(prisonerDetail, addOrEdit, id),

--- a/server/views/pages/adjustments/tagged-bail/days.njk
+++ b/server/views/pages/adjustments/tagged-bail/days.njk
@@ -4,6 +4,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set pageTitle = applicationName + " - Enter remand dates" %}
 {% set mainClasses = "app-container govuk-body" %}
@@ -29,23 +30,31 @@
     </div>
   </div>
   <p class="govuk-body">Enter the number of days as it’s written on the warrant.</p>
-  <div class="govuk-form-group govuk-body govuk-!-margin-top-6">
-
-    <label class="govuk-label" for="taggedBailDays">
-      Amount of days
-    </label>
-    <div class="govuk-input__wrapper"><input id="taggedBailDays" class="govuk-input govuk-input--width-5"  name="weight" type="text" spellcheck="false">
-      <div class="govuk-input__suffix" aria-hidden="true">days</div>
-    </div>
-  </div>
-
+  {{ govukInput({
+    label: {
+      text: "Amount of days"
+    },
+    classes: "govuk-input--width-5",
+    id: "days",
+    name: "days",
+    type: "number",
+    suffix: {
+      text: "days"
+    },
+    spellcheck: false
+  }) }}
 
   <div class="govuk-button-group">
-    <a href="review-tagged-bail.html" id="add-tagged-bail-days-button" class="govuk-button" data-name="ADA" data-desc="ADA (Additional days awarded)">
-      Continue
-    </a>
-    <a href="index.html" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-      Cancel
-    </a>
+    {{ govukButton({
+      text: "Continue",
+      type: submit,
+      preventDoubleClick: true,
+      attributes: { 'data-qa': 'submit-form' }
+    }) }}
+    {{ govukButton({
+      text: "Cancel",
+      classes: "govuk-button--secondary",
+      href: model.backlink()
+    }) }}
   </div>
 {% endblock %}

--- a/server/views/pages/adjustments/tagged-bail/days.njk
+++ b/server/views/pages/adjustments/tagged-bail/days.njk
@@ -1,10 +1,8 @@
 {% extends "../../../partials/layout.njk" %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set pageTitle = applicationName + " - Enter remand dates" %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/pages/adjustments/tagged-bail/days.njk
+++ b/server/views/pages/adjustments/tagged-bail/days.njk
@@ -1,0 +1,74 @@
+{% extends "../../../partials/layout.njk" %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% set pageTitle = applicationName + " - Enter remand dates" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {{ super() }}
+  <nav>
+    {{ govukBackLink({
+      text: "Back",
+      href: model.backlink()
+    }) }}
+  </nav>
+{% endblock %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-xl">Adjust release dates</span>
+        Select the case for this tagged bail
+      </h1>
+    </div>
+  </div>
+  <p class="govuk-body">You can add other periods of tagged bail later.</p>
+
+  <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-padding-left-0">
+
+    {% for activeSentence in model.activeSentences() %}
+      <div class="govuk-summary-card">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title">{{ activeSentence.courtDescription }}</h2>
+          <ul class="govuk-summary-card__actions">
+            <li class="govuk-summary-card__action">
+              <a class="govuk-link select-case-link" href="#">
+                Select this case
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="govuk-summary-card__content">
+          <dl class="govuk-summary-list">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Case reference
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ activeSentence.caseReference }}
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Warrant date
+              </dt>
+              <dd class="govuk-summary-list__value">
+                {{ activeSentence.sentenceDate | date("DD MMMM YYYY") }}
+              </dd>
+            </div>
+          </dl>
+        </div>
+      </div>
+    {% endfor %}
+
+    <div class="govuk-inset-text">
+      If you think some information is wrong, you can edit it in NOMIS and <a href="">reload this page</a>.
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/pages/adjustments/tagged-bail/days.njk
+++ b/server/views/pages/adjustments/tagged-bail/days.njk
@@ -24,17 +24,28 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">
         <span class="govuk-caption-xl">Adjust release dates</span>
-        Select the case for this tagged bail
+        Enter the amount of tagged bail
       </h1>
     </div>
   </div>
-  <p class="govuk-body">You can add other periods of tagged bail later.</p>
+  <p class="govuk-body">Enter the number of days as it’s written on the warrant.</p>
+  <div class="govuk-form-group govuk-body govuk-!-margin-top-6">
 
-  <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-padding-left-0">
-
-
-    <div class="govuk-inset-text">
-      If you think some information is wrong, you can edit it in NOMIS and <a href="">reload this page</a>.
+    <label class="govuk-label" for="taggedBailDays">
+      Amount of days
+    </label>
+    <div class="govuk-input__wrapper"><input id="taggedBailDays" class="govuk-input govuk-input--width-5"  name="weight" type="text" spellcheck="false">
+      <div class="govuk-input__suffix" aria-hidden="true">days</div>
     </div>
+  </div>
+
+
+  <div class="govuk-button-group">
+    <a href="review-tagged-bail.html" id="add-tagged-bail-days-button" class="govuk-button" data-name="ADA" data-desc="ADA (Additional days awarded)">
+      Continue
+    </a>
+    <a href="index.html" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+      Cancel
+    </a>
   </div>
 {% endblock %}

--- a/server/views/pages/adjustments/tagged-bail/days.njk
+++ b/server/views/pages/adjustments/tagged-bail/days.njk
@@ -32,40 +32,6 @@
 
   <div class="govuk-grid-column-two-thirds-from-desktop govuk-!-padding-left-0">
 
-    {% for activeSentence in model.activeSentences() %}
-      <div class="govuk-summary-card">
-        <div class="govuk-summary-card__title-wrapper">
-          <h2 class="govuk-summary-card__title">{{ activeSentence.courtDescription }}</h2>
-          <ul class="govuk-summary-card__actions">
-            <li class="govuk-summary-card__action">
-              <a class="govuk-link select-case-link" href="#">
-                Select this case
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div class="govuk-summary-card__content">
-          <dl class="govuk-summary-list">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Case reference
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ activeSentence.caseReference }}
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Warrant date
-              </dt>
-              <dd class="govuk-summary-list__value">
-                {{ activeSentence.sentenceDate | date("DD MMMM YYYY") }}
-              </dd>
-            </div>
-          </dl>
-        </div>
-      </div>
-    {% endfor %}
 
     <div class="govuk-inset-text">
       If you think some information is wrong, you can edit it in NOMIS and <a href="">reload this page</a>.

--- a/server/views/pages/adjustments/tagged-bail/select-case.njk
+++ b/server/views/pages/adjustments/tagged-bail/select-case.njk
@@ -38,7 +38,7 @@
           <h2 class="govuk-summary-card__title">{{ activeSentence.courtDescription }}</h2>
           <ul class="govuk-summary-card__actions">
             <li class="govuk-summary-card__action">
-              <a class="govuk-link select-case-link" href="#">
+              <a class="govuk-link" href="/{{ model.prisonerDetail.offenderNo }}/tagged-bail/days/{{ model.addOrEdit }}/{{ model.id }}?caseSequence={{ activeSentence.caseSequence }}">
                 Select this case
               </a>
             </li>


### PR DESCRIPTION
Also, rework select-case screen ( only show one case per case sequence, use the one with the earliest sentence date)

<img width="487" alt="image-20231218-101330" src="https://github.com/ministryofjustice/hmpps-adjustments/assets/3595969/4abcc53b-f0ae-4388-a50c-c5ec3979ee6b">
