### PR TITLE
CMG-88 Reduce the white space between the subnav and the page title

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -1,5 +1,6 @@
 .govuk-main-wrapper {
-  min-height: 600px
+  min-height: 600px;
+  padding-top: 0px;
 }
 
 .table-thick-bottom-border {


### PR DESCRIPTION
 Reduce padding for govuk-main-wrapper as subNav also has the same amount of padding. Before and after screenshots below

before:
![Screenshot from 2024-03-13 16-05-10](https://github.com/ministryofjustice/hmpps-adjustments/assets/3595969/6b865722-4567-46b5-a716-44ffc720f5aa)

after:
![Screenshot 2024-03-13 at 16 06 16](https://github.com/ministryofjustice/hmpps-adjustments/assets/3595969/64e8af4c-c93a-4e6a-8701-8fc0b5bc7036)
