### PR TITLE
CDIA-92: Update design version up to 5.0.2 to support blue notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@microsoft/applicationinsights-web": "^3.4.1",
     "@ministryofjustice/hmpps-audit-client": "^1.1.1",
     "@ministryofjustice/frontend": "^9.0.0",
-    "@ministryofjustice/hmpps-court-cases-release-dates-design": "^5.0.1",
+    "@ministryofjustice/hmpps-court-cases-release-dates-design": "^5.0.2",
     "agentkeepalive": "^4.6.0",
     "applicationinsights": "^2.9.8",
     "axe-core": "4.11.2",


### PR DESCRIPTION
Updated version of design package up to 5.0.2 to support blue notifications