### PR TITLE
CRS-2763: Allow display and delete on legacy tagged bail

### DIFF
--- a/server/model/tagged-bail/taggedBailRemoveModel.ts
+++ b/server/model/tagged-bail/taggedBailRemoveModel.ts
@@ -7,9 +7,9 @@ export default class TaggedBailRemoveModel {
   constructor(
     public prisonerNumber: string,
     public adjustment: Adjustment,
-    public sentenceAndOffence: PrisonApiOffenderSentenceAndOffences,
     public showUnusedMessage: boolean,
     public remandAndSentencingService: RemandAndSentencingService,
+    public sentenceAndOffence?: PrisonApiOffenderSentenceAndOffences,
     public reviewDeductions?: boolean,
   ) {}
 
@@ -26,7 +26,7 @@ export default class TaggedBailRemoveModel {
       [
         { text: 'Case details' },
         {
-          html: `${this.getCourtName()} <span class="vertical-bar"></span> ${this.getCaseReference()} ${this.remandAndSentencingService.isSentenceRecalled(this.sentenceAndOffence.sentenceCalculationType) ? getSentenceRecallTagHTML() : ''}<br>${this.getSentenceDate()}`,
+          html: `${this.getCourtName()} <span class="vertical-bar"></span> ${this.getCaseReference()} ${this.sentenceAndOffence && this.remandAndSentencingService.isSentenceRecalled(this.sentenceAndOffence.sentenceCalculationType) ? getSentenceRecallTagHTML() : ''}<br>${this.getSentenceDate()}`,
         },
       ],
       [{ text: 'Number of days' }, { text: this.getTaggedBailDays() }],
@@ -46,7 +46,7 @@ export default class TaggedBailRemoveModel {
       return this.sentenceAndOffence.courtDescription
     }
 
-    return null
+    return 'Unknown'
   }
 
   private getTaggedBailDays(): number {
@@ -62,7 +62,7 @@ export default class TaggedBailRemoveModel {
       return dateToString(new Date(this.sentenceAndOffence.sentenceDate))
     }
 
-    return null
+    return ''
   }
 
   private getCaseReference(): string {
@@ -70,6 +70,6 @@ export default class TaggedBailRemoveModel {
       return this.sentenceAndOffence.caseReference || ''
     }
 
-    return null
+    return 'Unknown'
   }
 }

--- a/server/model/tagged-bail/taggedBailViewModel.ts
+++ b/server/model/tagged-bail/taggedBailViewModel.ts
@@ -50,20 +50,34 @@ export default class TaggedBailViewModel {
       const sentencesForCaseSequence = this.sentencesByCaseSequence.find(sentencesByCaseSequence =>
         relevantSentenceForTaggedBailAdjustment(sentencesByCaseSequence, it),
       )
-      const sentenceAndOffence = getMostRecentSentenceAndOffence(sentencesForCaseSequence.sentences)
+      let recall = false
+      let caseReference: string
+      let courtDescription: string
+      let canEdit: boolean
+      if (sentencesForCaseSequence) {
+        const sentenceAndOffence = getMostRecentSentenceAndOffence(sentencesForCaseSequence.sentences)
 
-      const recall = this.remandAndSentencingService.isSentenceRecalled(
-        sentencesForCaseSequence.sentences[0].sentenceCalculationType,
-      )
+        recall = this.remandAndSentencingService.isSentenceRecalled(
+          sentencesForCaseSequence.sentences[0].sentenceCalculationType,
+        )
+        caseReference = sentenceAndOffence.caseReference
+        courtDescription = sentenceAndOffence.courtDescription
+        canEdit = true
+      } else {
+        caseReference = 'Unknown'
+        courtDescription = 'Unknown'
+        canEdit = false
+      }
+
       const descriptionRow = recall
-        ? { html: `${sentenceAndOffence.courtDescription} ${getSentenceRecallTagHTML()}` }
-        : { text: sentenceAndOffence.courtDescription }
+        ? { html: `${courtDescription} ${getSentenceRecallTagHTML()}` }
+        : { text: courtDescription }
 
       return [
         descriptionRow,
-        { text: sentenceAndOffence.caseReference },
+        { text: caseReference },
         { text: it.days },
-        this.actionCell(it, sentenceAndOffence.caseReference, sentenceAndOffence.courtDescription),
+        this.actionCell(it, caseReference, courtDescription, canEdit),
       ]
     })
   }
@@ -81,20 +95,23 @@ export default class TaggedBailViewModel {
     return [[{ html: '<b>Total days</b>' }, { html: '' }, { html: `<b>${total}</b>` }, { text: '' }]]
   }
 
-  private actionCell(adjustment: Adjustment, caseReference: string, courtDescription: string) {
+  private actionCell(adjustment: Adjustment, caseReference: string, courtDescription: string, canEdit: boolean) {
     const visuallyHiddenText = caseReference
       ? `tagged bail for case ${caseReference} at ${courtDescription}`
       : `${adjustment.days} days of tagged bail at ${courtDescription}`
 
-    return {
-      html: `
+    let html = ''
+    if (canEdit) {
+      html += `
       <div class="govuk-grid-column-one-quarter govuk-!-margin-right-2 govuk-!-padding-0">
         <a class="govuk-link" href="/${adjustment.person}/tagged-bail/edit/${adjustment.id}" data-qa="edit-${adjustment.id}">Edit<span class="govuk-visually-hidden"> ${visuallyHiddenText}</span></a><br />
-      </div>
+      </div>`
+    }
+    html += `
       <div class="govuk-grid-column-one-half govuk-!-padding-0">
         <a class="govuk-link" href="/${adjustment.person}/tagged-bail/remove/${adjustment.id}" data-qa="delete-${adjustment.id}">Delete<span class="govuk-visually-hidden"> ${visuallyHiddenText}</span></a><br />
       </div>
-    `,
-    }
+    `
+    return { html }
   }
 }

--- a/server/routes/taggedBailRoutes.test.ts
+++ b/server/routes/taggedBailRoutes.test.ts
@@ -203,7 +203,24 @@ describe('Tagged bail routes tests', () => {
       })
   })
 
-  it('GET /{nomsId}/tagged-bail/remove shows correct information', () => {
+  it('GET /{nomsId}/tagged-bail/view NOMIS adjustment with inactive sentence displays correctly and only allows delete', () => {
+    prisonerService.getSentencesAndOffences.mockResolvedValue(stubbedSentencesAndOffences)
+    unusedDeductionsService.getCalculatedUnusedDeductionsMessageAndAdjustments.mockResolvedValue([
+      'NONE',
+      [{ ...nomisAdjustment, sentenceSequence: 99 }],
+    ])
+    return request(app)
+      .get(`/${NOMS_ID}/tagged-bail/view`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Tagged bail overview')
+        expect(res.text).toContain('Unknown')
+        expect(res.text).not.toContain('Edit')
+        expect(res.text).toContain('Delete')
+      })
+  })
+
+  it('GET /{nomsId}/tagged-bail/remove shows correct information for DPS adjustment', () => {
     prisonerService.getSentencesAndOffences.mockResolvedValue(stubbedSentencesAndOffences)
     adjustmentsService.findByPerson.mockResolvedValue([populatedAdjustment])
     adjustmentsService.get.mockResolvedValue(populatedAdjustment)
@@ -217,16 +234,31 @@ describe('Tagged bail routes tests', () => {
       })
   })
 
-  it('GET /{nomsId}/tagged-bail/remove shows correct information', () => {
+  it('GET /{nomsId}/tagged-bail/remove shows correct information for NOMIS adjustment', () => {
     prisonerService.getSentencesAndOffences.mockResolvedValue(stubbedSentencesAndOffences)
     adjustmentsService.findByPerson.mockResolvedValue([nomisAdjustment])
-    adjustmentsService.get.mockResolvedValue(populatedAdjustment)
+    adjustmentsService.get.mockResolvedValue(nomisAdjustment)
     return request(app)
       .get(`/${NOMS_ID}/tagged-bail/remove/1`)
       .expect(200)
       .expect(res => {
         expect(res.text).toContain('Delete tagged bail')
         expect(res.text).toContain('Court 2 <span class="vertical-bar"></span> CASE001 <br>19 August 2021')
+        expect(res.text).toContain('9955')
+      })
+  })
+
+  it('GET /{nomsId}/tagged-bail/remove shows correct information for NOMIS adjustment against inactive sentence', () => {
+    prisonerService.getSentencesAndOffences.mockResolvedValue(stubbedSentencesAndOffences)
+    const nomisAdjustmentAgainstInactiveSentence = { ...nomisAdjustment, sentenceSequence: 99 }
+    adjustmentsService.findByPerson.mockResolvedValue([nomisAdjustmentAgainstInactiveSentence])
+    adjustmentsService.get.mockResolvedValue(nomisAdjustmentAgainstInactiveSentence)
+    return request(app)
+      .get(`/${NOMS_ID}/tagged-bail/remove/1`)
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Delete tagged bail')
+        expect(res.text).toContain('Unknown <span class="vertical-bar"></span> Unknown')
         expect(res.text).toContain('9955')
       })
   })

--- a/server/routes/taggedBailRoutes.ts
+++ b/server/routes/taggedBailRoutes.ts
@@ -176,7 +176,9 @@ export default class TaggedBailRoutes {
       relevantSentenceForTaggedBailAdjustment(it, adjustment),
     )
 
-    const sentenceAndOffence = getMostRecentSentenceAndOffence(sentencesForCaseSequence.sentences)
+    const sentenceAndOffence = sentencesForCaseSequence
+      ? getMostRecentSentenceAndOffence(sentencesForCaseSequence.sentences)
+      : null
 
     const adjustments = await this.adjustmentsService.getAdjustmentsExceptOneBeingEdited(
       { [id]: adjustment },
@@ -203,9 +205,9 @@ export default class TaggedBailRoutes {
       model: new TaggedBailRemoveModel(
         prisonerNumber,
         adjustment,
-        sentenceAndOffence,
         showUnusedMessage,
         this.remandAndSentencingService,
+        sentenceAndOffence,
         reviewDeductions,
       ),
     })


### PR DESCRIPTION
Sometimes a tagged bail is inadvertently created as part of a NOMIS recall where an old sentence was selected. As the sentence is expired and no longer active this means there is no sentence and offence information.

To allow users to delete these invalid legacy adjustments we will display 'Unknown' in place of the case information.